### PR TITLE
[feature] include github action metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ conda channel and can be used to install the package.
 
 ```shell
 $ conda install -c ./dist/conda <package-name>
+...
 ```
 
 ## Conda-build Options
@@ -51,10 +52,20 @@ header.
 
 Following table contains available customization of builder behavior.
 
-| Option                | Type      | Default         | Description                                      |
-|:----------------------|:----------|:----------------|:-------------------------------------------------|
-| channels              | list[str] | ['conda-forge'] | Channels used for package build and testing      |
-| default_numpy_version | str       | None            | numpy version, otherwise use conda-build default |
+| Option                 | Type      | Default         | Description                                      |
+|:-----------------------|:----------|:----------------|:-------------------------------------------------|
+| channels               | list[str] | ['conda-forge'] | Channels used for package build and testing      |
+| default_numpy_version  | str       | None            | numpy version, otherwise use conda-build default |
+| github_action_metadata | bool      | false           | Include extra metadata into recipe from Github runner environment variables|
+
+When `github_action_metadata` is True and the [Github runner environment variables](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables) are present, the follow metadata is added to the 
+`extra` section of the recipe:
+
+| Variable(s)                          | Field         | Value           |
+|:-------------------------------------|:--------------|:----------------|
+| GITHUB_SHA                           | `sha`         | `${GITHUB_SHA}` |
+| GITHUB_SERVER_URL<br>GITHUB_REPOSITORY | `remote_url`  | `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}` |
+| GITHUB_RUN_ID                        | `flow_run_id` | `${GITHUB_RUN_ID}` |
 
 ### Modifying the generated recipe
 

--- a/src/hatch_conda_build/plugin.py
+++ b/src/hatch_conda_build/plugin.py
@@ -164,7 +164,9 @@ class CondaBuilder(BuilderInterface):
             if "GITHUB_SHA" in os.environ:
                 conda_meta["extra"]["sha"] = os.environ["GITHUB_SHA"]
             if "GITHUB_SERVER_URL" in os.environ and "GITHUB_REPOSITORY" in os.environ:
-                conda_meta["extra"]["remote_url"] = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}"
+                conda_meta["extra"][
+                    "remote_url"
+                ] = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}"
             if "GITHUB_RUN_ID" in os.environ:
                 conda_meta["extra"]["flow_run_id"] = os.environ["GITHUB_RUN_ID"]
 

--- a/src/hatch_conda_build/plugin.py
+++ b/src/hatch_conda_build/plugin.py
@@ -1,11 +1,12 @@
-import json
-import shutil
-import sys
-import typing
-import pathlib
 import collections
-import tempfile
+import json
+import os
+import pathlib
+import shutil
 import subprocess
+import sys
+import tempfile
+import typing
 from deepmerge.merger import Merger
 from pathlib import Path
 from typing import Optional, List
@@ -157,6 +158,15 @@ class CondaBuilder(BuilderInterface):
         conda_meta["about"]["summary"] = self.metadata.core_raw_metadata.get(
             "description"
         )
+
+        github_action_metadata = self.target_config.get("github_action_metadata", False)
+        if github_action_metadata:
+            if "GITHUB_SHA" in os.environ:
+                conda_meta["extra"]["sha"] = os.environ["GITHUB_SHA"]
+            if "GITHUB_SERVER_URL" in os.environ and "GITHUB_REPOSITORY" in os.environ:
+                conda_meta["extra"]["remote_url"] = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}"
+            if "GITHUB_RUN_ID" in os.environ:
+                conda_meta["extra"]["flow_run_id"] = os.environ["GITHUB_RUN_ID"]
 
         # merge extra keys and overrides
         extras = self.target_config.get("recipe", {})

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -157,7 +157,7 @@ def test_with_github_action_extra_metadata(monkeypatch, project_factory):
     """
     )
     project = project_factory(more_toml=target_config)
-    
+
     monkeypatch.setenv("GITHUB_SHA", "000000")
     monkeypatch.setenv("GITHUB_SERVER_URL", "http://example.com")
     monkeypatch.setenv("GITHUB_REPOSITORY", "repo")
@@ -179,7 +179,7 @@ def test_without_github_action_extra_metadata(monkeypatch, project_factory):
     """
     )
     project = project_factory(more_toml=target_config)
-    
+
     monkeypatch.setenv("GITHUB_SHA", "000000")
     monkeypatch.setenv("GITHUB_SERVER_URL", "http://example.com")
     monkeypatch.setenv("GITHUB_REPOSITORY", "repo")
@@ -212,7 +212,7 @@ def test_with_github_action_extra_metadata_missing_vars(project_factory):
 
 def test_default_without_github_action_extra_metadata(monkeypatch, project_factory):
     project = project_factory()
-    
+
     monkeypatch.setenv("GITHUB_SHA", "000000")
     monkeypatch.setenv("GITHUB_SERVER_URL", "http://example.com")
     monkeypatch.setenv("GITHUB_REPOSITORY", "repo")


### PR DESCRIPTION
When enabled, github action metadata is added to the `extra` section. By default `github_action_metadata` is false. When true env vars are inspected for `GITHUB_` entries to populate the metadata.

```toml
[tool.hatch.targets.conda]
github_action_metadata = true
```

Here's an example.

```
❯ GITHUB_SHA=00000 GITHUB_SERVER_URL='https://github.com' GITHUB_REPOSITORY='owner/repo' GITHUB_RUN_ID='123456' hatch build -t conda
...
❯ unzip -p ./dist/conda/noarch/<package>-<version>-py_0.conda info-<package>-<version>-py_0.tar.zst | tar -x -O info/recipe/meta.yaml | sed -n '/extra:/,$p'
extra:
  copy_test_source_files: true
  final: true
  flow_run_id: '123456'
  remote_url: https://github.com/owner/repo
  sha: '00000'
```