### PR TITLE
[chore] include full source tree for testing

### DIFF
--- a/src/hatch_conda_build/plugin.py
+++ b/src/hatch_conda_build/plugin.py
@@ -149,7 +149,9 @@ class CondaBuilder(BuilderInterface):
         conda_meta["requirements"] = self._get_requirements()
 
         # test
-        conda_meta["test"] = {}
+        conda_meta["test"] = {
+            "source_files": ["."]
+        }
 
         # about
         conda_meta["about"]["home"] = self.metadata.core_raw_metadata.get(

--- a/src/hatch_conda_build/plugin.py
+++ b/src/hatch_conda_build/plugin.py
@@ -149,9 +149,7 @@ class CondaBuilder(BuilderInterface):
         conda_meta["requirements"] = self._get_requirements()
 
         # test
-        conda_meta["test"] = {
-            "source_files": ["."]
-        }
+        conda_meta["test"] = {"source_files": ["."]}
 
         # about
         conda_meta["about"]["home"] = self.metadata.core_raw_metadata.get(

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -226,6 +226,15 @@ def test_default_without_github_action_extra_metadata(monkeypatch, project_facto
     assert "flow_run_id" not in recipe["extra"]
 
 
+def test_source_files_for_testing(project_factory):
+    project = project_factory()
+
+    builder = CondaBuilder(root=project)
+    recipe = builder._construct_recipe()
+
+    assert recipe.get("test", {}).get("source_files", []) == ["."]
+
+
 @pytest.mark.slow()
 def test_noarch_build(project_factory):
     project = project_factory()


### PR DESCRIPTION
Previously I was having trouble adding a `test.commands` section like so

```toml
[tool.hatch.build.targets.conda.recipe]
tests.commands = ["pytest"]
```
 
where pytest would fail and its because the configuration should have been

```toml
[tool.hatch.build.targets.conda.recipe]
test.source_files = ["."]
test.commands = ["pytest"]
```

This pr makes `test.source_files = ["."]` default