### PR TITLE
Change meta.yaml from JSON to YAML format

### DIFF
--- a/src/hatch_conda_build/plugin.py
+++ b/src/hatch_conda_build/plugin.py
@@ -22,6 +22,7 @@ from grayskull.config import Configuration
 from grayskull.strategy.pypi import extract_requirements, normalize_requirements_list
 from grayskull.strategy.pypi import merge_pypi_sdist_metadata
 
+from ruamel.yaml import YAML
 
 recipe_merger = Merger(
     type_strategies=[(dict, ["merge"]), (list, ["append"])],
@@ -53,7 +54,8 @@ def conda_build(
 ):
     conda_meta_filename = build_directory / "meta.yaml"
     with conda_meta_filename.open("w") as f:
-        json.dump(meta_config, f)
+        yaml = YAML()
+        yaml.dump(dict(meta_config), f)
 
     command = [
         "conda",


### PR DESCRIPTION
If the meta.yaml file is in JSON format, platform selectors, like

dependencies = [
    'pywin32 >= 224; sys_platform == "win32"',
]

don't work. Switching to a normal yaml file (which seems to be the same thing that Grayskull does) fixes the issue (ref issue #15).